### PR TITLE
Sshd config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Key | Type | Description | Default
 --- | ---- | ----------- | -------
 `['cygwin']['ssh']['sshd_user']` | String | User to run sshd as | `cyg_server`
 `['cygwin']['ssh']['sshd_passwd']` | String | Password for the sshd user | `nil`
+`['cygwin']['ssh']['kexalgorithms']` | String | List of hashes to support | `nil`
+
 
 ## License and Authors
 

--- a/attributes/ssh.rb
+++ b/attributes/ssh.rb
@@ -14,3 +14,9 @@
 
 default['cygwin']['ssh']['sshd_user'] = 'cyg_server'
 default['cygwin']['ssh']['sshd_passwd'] = nil
+default['cygwin']['ssh']['kexalgorithms'] = 'diffie-hellman-group-exchange-sha1,
+                                            diffie-hellman-group1-sha1,
+                                            ecdh-sha2-nistp521,
+                                            ecdh-sha2-nistp384,
+                                            ecdh-sha2-nistp256,
+                                            diffie-hellman-group-exchange-sha256'

--- a/attributes/ssh.rb
+++ b/attributes/ssh.rb
@@ -14,9 +14,4 @@
 
 default['cygwin']['ssh']['sshd_user'] = 'cyg_server'
 default['cygwin']['ssh']['sshd_passwd'] = nil
-default['cygwin']['ssh']['kexalgorithms'] = 'diffie-hellman-group-exchange-sha1,
-                                            diffie-hellman-group1-sha1,
-                                            ecdh-sha2-nistp521,
-                                            ecdh-sha2-nistp384,
-                                            ecdh-sha2-nistp256,
-                                            diffie-hellman-group-exchange-sha256'
+default['cygwin']['ssh']['kexalgorithms'] = 'diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'engops@bluemedora.com'
 license          'Apache 2.0'
 description      'Installs/Configures cygwin'
 long_description 'Installs/Configures cygwin'
-version          '0.7.1'
+version          '0.7.2'
 
 supports 'windows', '> 0.0'
 depends 'windows', '> 0.0'

--- a/recipes/ssh.rb
+++ b/recipes/ssh.rb
@@ -14,7 +14,7 @@
 
 include_recipe "cygwin::default"
 
-if node['cygwin']['ssh']['sshd_passwd'].nil? 
+if node['cygwin']['ssh']['sshd_passwd'].nil?
     raise "You MUST define a password for the sshd privileged user in your attributes! (node['cygwin']['ssh']['sshd_passwd'])"
 end
 
@@ -26,8 +26,12 @@ packages.each do |pkg|
     end
 end
 
+template 'C:/cygwin/etc/sshd_config' do
+  source 'sshd_config.erb'
+end
+
 execute 'Stop sshd' do
-    cwd 'C:\cygwin\bin' 
+    cwd 'C:\cygwin\bin'
     environment ({'PATH' => '$PATH:.:/cygdrive/c/cygwin/bin'})
     command 'cygrunsrv -E sshd'
     only_if 'cygrunsrv -Q sshd'
@@ -37,7 +41,7 @@ execute 'Configure sshd service' do
     cwd 'C:\cygwin\bin'
     environment ({'PATH' => '$PATH:.:/cygdrive/c/cygwin/bin'})
     command "bash /usr/bin/ssh-host-config --yes --cygwin \"ntsec\" --user #{node['cygwin']['ssh']['sshd_user']} --pwd \"#{node['cygwin']['ssh']['sshd_passwd']}\" "
-    not_if('cygrunsrv -Q sshd').include? 'Running' 
+    not_if('cygrunsrv -Q sshd').include? 'Running'
 end
 
 execute 'Make sure the password does not expire' do
@@ -45,7 +49,7 @@ execute 'Make sure the password does not expire' do
 end
 
 execute 'Start sshd' do
-    cwd 'C:\cygwin\bin' 
+    cwd 'C:\cygwin\bin'
     environment ({'PATH' => '$PATH:.:/cygdrive/c/cygwin/bin'})
     command 'cygrunsrv -S sshd'
     not_if ('cygrunsrv -Q sshd').include?('Running')

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -1,0 +1,122 @@
+# Managed by Chef
+
+#	$OpenBSD: sshd_config,v 1.101 2017/03/14 07:19:07 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/bin:/usr/sbin:/sbin:/usr/bin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh_host_rsa_key
+#HostKey /etc/ssh_host_dsa_key
+#HostKey /etc/ssh_host_ecdsa_key
+#HostKey /etc/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+#PasswordAuthentication yes
+#PermitEmptyPasswords no
+
+# Change to no to disable s/key passwords
+#ChallengeResponseAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+#X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem	sftp	/usr/sbin/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server
+
+KexAlgorithms <%=node['cygwin']['ssh']['kexalgorithms']%>


### PR DESCRIPTION
Cookbook now deploys a sshd_config template before starting the service for the first time. 

Added an attribute to set the HexAlgorithms directive. This should be overriden with a role if secure algorithms are desired. By default legacy algorithms are enabled. 

Resolves https://github.com/BlueMedoraPublic/cookbook-cygwin/issues/2

